### PR TITLE
Bump `ghostwriter/coding-standard` from `dev-main`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1873,12 +1873,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "7f141b119721d61069156042d3dd3402087d8938"
+                "reference": "5f66842d4f9727b92be55eea5ec0acebccf7b9d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/7f141b119721d61069156042d3dd3402087d8938",
-                "reference": "7f141b119721d61069156042d3dd3402087d8938",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/5f66842d4f9727b92be55eea5ec0acebccf7b9d3",
+                "reference": "5f66842d4f9727b92be55eea5ec0acebccf7b9d3",
                 "shasum": ""
             },
             "require": {
@@ -2035,7 +2035,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-24T15:04:20+00:00"
+            "time": "2025-08-24T19:11:35+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main`.

This pull request changes the following file(s): 

- Update `composer.lock`