### PR TITLE
Bump `ghostwriter/workbench` from `0.1.x-dev#9b665a0` to `0.1.x-dev#c809f01`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1535,12 +1535,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/workbench.git",
-                "reference": "9b665a047e0c2438911297bec5e1f8f17fc3d3fb"
+                "reference": "c809f013335358f330dff9c9389951730bdff9df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/workbench/zipball/9b665a047e0c2438911297bec5e1f8f17fc3d3fb",
-                "reference": "9b665a047e0c2438911297bec5e1f8f17fc3d3fb",
+                "url": "https://api.github.com/repos/ghostwriter/workbench/zipball/c809f013335358f330dff9c9389951730bdff9df",
+                "reference": "c809f013335358f330dff9c9389951730bdff9df",
                 "shasum": ""
             },
             "require": {
@@ -1621,7 +1621,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-02T00:57:41+00:00"
+            "time": "2025-09-02T02:14:01+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Bumps `ghostwriter/workbench` from `0.1.x-dev#9b665a0` to `0.1.x-dev#c809f01`.

This pull request changes the following file(s): 

- Update `composer.lock`