### PR TITLE
Update symfony/var-dumper to version 7.3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "ghostwriter/container": "^5.0.1",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^12.4.1",
-        "symfony/var-dumper": "^7.3.4"
+        "symfony/var-dumper": "^7.3.5"
     },
     "prefer-stable": true,
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2c673b3c07fcbfa450dbecfd24738f5b",
+    "content-hash": "f1c4e6c1adb50788e36efc6a61b0fa20",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -4787,16 +4787,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.3.4",
+            "version": "v7.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "b8abe7daf2730d07dfd4b2ee1cecbf0dd2fbdabb"
+                "reference": "476c4ae17f43a9a36650c69879dcf5b1e6ae724d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/b8abe7daf2730d07dfd4b2ee1cecbf0dd2fbdabb",
-                "reference": "b8abe7daf2730d07dfd4b2ee1cecbf0dd2fbdabb",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/476c4ae17f43a9a36650c69879dcf5b1e6ae724d",
+                "reference": "476c4ae17f43a9a36650c69879dcf5b1e6ae724d",
                 "shasum": ""
             },
             "require": {
@@ -4850,7 +4850,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.3.4"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.3.5"
             },
             "funding": [
                 {
@@ -4870,7 +4870,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-11T10:12:26+00:00"
+            "time": "2025-09-27T09:00:46+00:00"
         },
         {
             "name": "theseer/tokenizer",


### PR DESCRIPTION
Updates the `symfony/var-dumper` dependency from `v7.3.4` to `7.3.5`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`