### PR TITLE
Update ghostwriter/coding-standard to version dev-main#76bcbf3

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -722,12 +722,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "e55508fc3e92c62bac0a6b88a870f4cb09e8fd84"
+                "reference": "76bcbf37368132f07904b57959d1c896ae089297"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/e55508fc3e92c62bac0a6b88a870f4cb09e8fd84",
-                "reference": "e55508fc3e92c62bac0a6b88a870f4cb09e8fd84",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/76bcbf37368132f07904b57959d1c896ae089297",
+                "reference": "76bcbf37368132f07904b57959d1c896ae089297",
                 "shasum": ""
             },
             "require": {
@@ -903,7 +903,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-06T12:23:26+00:00"
+            "time": "2025-12-06T14:14:36+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#e55508f` to `dev-main#76bcbf3`.

This pull request changes the following file(s): 

- Update `composer.lock`