### PR TITLE
Update phpunit/phpunit to version 12.5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/container": "^6.0.1",
         "mockery/mockery": "^1.6.12",
-        "phpunit/phpunit": "^12.5.3",
+        "phpunit/phpunit": "^12.5.4",
         "symfony/var-dumper": "^8.0.0"
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "81c95eabad32d4f792c728c28bdfc590",
+    "content-hash": "4f6fdb2f6087b82e16e0894ff7bedfc1",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -1981,16 +1981,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.3",
+            "version": "12.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6dc2e076d09960efbb0c1272aa9bc156fc80955e"
+                "reference": "4ba0e923f9d3fc655de22f9547c01d15a41fc93a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6dc2e076d09960efbb0c1272aa9bc156fc80955e",
-                "reference": "6dc2e076d09960efbb0c1272aa9bc156fc80955e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4ba0e923f9d3fc655de22f9547c01d15a41fc93a",
+                "reference": "4ba0e923f9d3fc655de22f9547c01d15a41fc93a",
                 "shasum": ""
             },
             "require": {
@@ -2058,7 +2058,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.3"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.4"
             },
             "funding": [
                 {
@@ -2082,7 +2082,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-11T08:52:59+00:00"
+            "time": "2025-12-15T06:05:34+00:00"
         },
         {
             "name": "psr/container",


### PR DESCRIPTION
Updates the `phpunit/phpunit` dependency from `12.5.3` to `12.5.4`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`