### PR TITLE
Update boundwize/structarmed to version 0.5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.5.4",
+        "boundwize/structarmed": "^0.5.5",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/container": "^7.0.1",
         "mockery/mockery": "^1.6.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "23935b00d28d20d3029ab5c3beaec3bd",
+    "content-hash": "e595b89788fd0a1a3eec58c238e7c1c0",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -99,16 +99,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.5.4",
+            "version": "0.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "1b75ee70748fb570aa9241de334139f08544e0fe"
+                "reference": "6da18d0c62553831e402250940d75df04a8c3bc8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/1b75ee70748fb570aa9241de334139f08544e0fe",
-                "reference": "1b75ee70748fb570aa9241de334139f08544e0fe",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/6da18d0c62553831e402250940d75df04a8c3bc8",
+                "reference": "6da18d0c62553831e402250940d75df04a8c3bc8",
                 "shasum": ""
             },
             "require": {
@@ -157,7 +157,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.5.4"
+                "source": "https://github.com/boundwize/structarmed/tree/0.5.5"
             },
             "funding": [
                 {
@@ -165,7 +165,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-14T14:37:07+00:00"
+            "time": "2026-05-15T13:59:43+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.5.4` to `0.5.5`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`