### PR TITLE
Update boundwize/structarmed to version 0.6.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.6.2",
+        "boundwize/structarmed": "^0.6.4",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/container": "^7.0.1",
         "mockery/mockery": "^1.6.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e6631c21185a4979a888c8148878d7a5",
+    "content-hash": "f12cce6f69c95a83ed46ab8032021177",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -99,16 +99,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.6.2",
+            "version": "0.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "e85dcdf401fd3971f5389893862ab999eead1569"
+                "reference": "8d630745f6e26f9c4c4d8886da913ba5264ff47b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/e85dcdf401fd3971f5389893862ab999eead1569",
-                "reference": "e85dcdf401fd3971f5389893862ab999eead1569",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/8d630745f6e26f9c4c4d8886da913ba5264ff47b",
+                "reference": "8d630745f6e26f9c4c4d8886da913ba5264ff47b",
                 "shasum": ""
             },
             "require": {
@@ -157,7 +157,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.6.2"
+                "source": "https://github.com/boundwize/structarmed/tree/0.6.4"
             },
             "funding": [
                 {
@@ -165,7 +165,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-16T07:16:18+00:00"
+            "time": "2026-05-16T17:20:29+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -234,16 +234,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "968292530cd54c945f08907d664cfc16c5a4668d"
+                "reference": "2c20193be3316dcd85999c946d35b9051576ae97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/968292530cd54c945f08907d664cfc16c5a4668d",
-                "reference": "968292530cd54c945f08907d664cfc16c5a4668d",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/2c20193be3316dcd85999c946d35b9051576ae97",
+                "reference": "2c20193be3316dcd85999c946d35b9051576ae97",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.6.2",
+                "boundwize/structarmed": "^0.6.4",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -354,7 +354,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-16T11:04:23+00:00"
+            "time": "2026-05-16T17:56:23+00:00"
         },
         {
             "name": "ghostwriter/container",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.6.2` to `0.6.4`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`