### PR TITLE
Update `boundwize/structarmed` to version `0.9.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.8.7",
+        "boundwize/structarmed": "^0.9.1",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/container": "^7.0.2",
         "ghostwriter/phpunit-assertions": "^0.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b455ff59378cbefc4a792a809096978",
+    "content-hash": "56455f6b29db2b7ea4c750c8da6e7be8",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -99,16 +99,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.8.7",
+            "version": "0.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "dc9909606c1f4e6619330c95e5a9e5dbaaa981af"
+                "reference": "c2a07a6d62880c0075f3ce672e44496e28a95292"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/dc9909606c1f4e6619330c95e5a9e5dbaaa981af",
-                "reference": "dc9909606c1f4e6619330c95e5a9e5dbaaa981af",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/c2a07a6d62880c0075f3ce672e44496e28a95292",
+                "reference": "c2a07a6d62880c0075f3ce672e44496e28a95292",
                 "shasum": ""
             },
             "require": {
@@ -161,7 +161,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.8.7"
+                "source": "https://github.com/boundwize/structarmed/tree/0.9.1"
             },
             "funding": [
                 {
@@ -169,7 +169,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-29T11:10:29+00:00"
+            "time": "2026-05-29T15:52:29+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the [`boundwize/structarmed`](https://packagist.org/packages/boundwize/structarmed) dependency from `0.8.7` to `0.9.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`