### PR TITLE
Update `boundwize/structarmed` to version `0.17.3`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.17.2",
+        "boundwize/structarmed": "^0.17.3",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/container": "^7.0.2",
         "ghostwriter/phpunit-assertions": "^0.1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "983cd6c586623c927346cf12b0e8c275",
+    "content-hash": "1216c5dc224ef73366faef6099aebb81",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -168,16 +168,16 @@
         },
         {
             "name": "boundwize/structarmed",
-            "version": "0.17.2",
+            "version": "0.17.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "4c9b8d1250ca19261ddf088199296e22d837d618"
+                "reference": "b6a6876aa7e5efb6e012045be9394b2994cd145b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/4c9b8d1250ca19261ddf088199296e22d837d618",
-                "reference": "4c9b8d1250ca19261ddf088199296e22d837d618",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/b6a6876aa7e5efb6e012045be9394b2994cd145b",
+                "reference": "b6a6876aa7e5efb6e012045be9394b2994cd145b",
                 "shasum": ""
             },
             "require": {
@@ -234,7 +234,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.17.2"
+                "source": "https://github.com/boundwize/structarmed/tree/0.17.3"
             },
             "funding": [
                 {
@@ -242,7 +242,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-09-07T14:34:27+00:00"
+            "time": "2026-09-10T17:44:24+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the [`boundwize/structarmed`](https://packagist.org/packages/boundwize/structarmed) dependency from `0.17.2` to `0.17.3`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`